### PR TITLE
Code cleanup, new and more standardized options.

### DIFF
--- a/src/att.c
+++ b/src/att.c
@@ -55,14 +55,3 @@ void genpass599(uint32_t x, unsigned char *psk) {
 		psk[ATT_NVG5XX_PSK_LEN - i - 1] = CHARSET[one % 37];
 	}
 }
-
-// nvg599 password algorithm
-/*void genpass599(unsigned x, unsigned char *buf) {
-   static const char CHARSET[] = "abcdefghijkmnpqrstuvwxyz23456789#%+=?";
-   buf[12] = 0; // create buffer for password
-
-   fnn = (double) (x * ((1l << 32) + 2));
-   for (i = 1; i < PW_LENGTH; i++, fnn /= 37) {
-   buf[PW_LENGTH - i - 1] = CHARSET[fnn % 37];
-   }
-   }*/

--- a/src/att.c
+++ b/src/att.c
@@ -1,4 +1,24 @@
 /*
+ * PSKracker: WPA/WPA2/WPS default key/pin generator written in C.
+ *
+ * Copyright (c) 2017, soxrok2212 <soxrok2212@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0+
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
  * Thank you to mrfancypants for research and preliminary Python code for ATTXXXXXXX networks.
  */
 

--- a/src/pskracker.c
+++ b/src/pskracker.c
@@ -69,10 +69,11 @@ void usage_err() {
 }
 
 // target selection
-enum model {nvg589 = 0x00, nvg599 = 0x01, ENDMODEL = END};
+enum model {nvg589 = 0x00, nvg599 = 0x01, dpc3939 = 0x02, dpc3941 = 0x03, tg1682g = 0x04, ENDMODEL = END};
 enum encryption {wpa = 0x00, wpa2 = 0x01, wps = 0x02, ENDENC = 0x03};
+
 enum model getModel(char *inModel) {
-	static const char *models[] = {"nvg589", "nvg599"};
+	static const char *models[] = {"nvg589", "nvg599", "dpc3939", "dpc3941", "tg1682g"};
 	uint8_t i;
 	for(i = 0; i < ENDMODEL; ++i) {
 		if(!strcmp(models[i], inModel)) {
@@ -81,6 +82,7 @@ enum model getModel(char *inModel) {
 	}
 	return ENDMODEL;
 }
+
 enum encryption getEncryption(char *inEnc) {
 	static const char *enctypes[] = {"wpa", "wpa2", "wps"};
 	uint8_t i;
@@ -93,31 +95,29 @@ enum encryption getEncryption(char *inEnc) {
 }
 
 void bruteforce(uint8_t m, uint8_t e, uint8_t *mac) {
-	switch(m) {
 
-		case 0: {
-			int32_t i;
-			unsigned char psk[ATT_NVG5XX_PSK_LEN];
-			for (i = 0; i < INT_MAX; i++) {
-				genpass589(i, psk);
-				printf("%s\n", psk);
-			}
+	if(m == 0) {
+		int32_t i;
+		unsigned char psk[ATT_NVG5XX_PSK_LEN];
+		for (i = 0; i < INT_MAX; i++) {
+			genpass589(i, psk);
+			printf("%s\n", psk);
 		}
-		break;
-
-		case 1: {
-			int32_t i;
-			unsigned char psk[ATT_NVG5XX_PSK_LEN];
-			for (i = 0; i < INT_MAX; i++) {
-				genpass599(i, psk);
-				printf("%s\n", psk);
-			}
+	}
+	else if(m == 1) {
+		int32_t i;
+		unsigned char psk[ATT_NVG5XX_PSK_LEN];
+		for (i = 0; i < INT_MAX; i++) {
+			genpass599(i, psk);
+			printf("%s\n", psk);
 		}
-		break;
-
-		default:
-			usage_err();
-		break;
+	}
+	else if(m == 2 || m == 3 || m == 4) {
+		if(mac == NULL) {
+			printf("Invalid MAC address\n");
+			exit(1);
+		}
+		printf("PSK: %s\n", genpassXHS(mac));
 	}
 }
 
@@ -148,7 +148,7 @@ int main(int argc, char **argv) {
 
 		case 'm': // mac address selection
 			if (hex_string_to_byte_array(optarg, mac, BSSID_LEN)) {
-				printf("Invalid MAC Address\n");
+				printf("Invalid MAC address\n");
 				exit(2);
 			}
 			pMac = mac;

--- a/src/pskracker.c
+++ b/src/pskracker.c
@@ -94,9 +94,9 @@ enum encryption getEncryption(char *inEnc) {
 	return ENDENC;
 }
 
-void bruteforce(uint8_t m, uint8_t e, uint8_t *mac) {
+void bruteforce(uint8_t model, uint8_t enc, uint8_t *mac) {
 
-	if(m == 0) {
+	if(model == 0x00) {
 		int32_t i;
 		unsigned char psk[ATT_NVG5XX_PSK_LEN];
 		for (i = 0; i < INT_MAX; i++) {
@@ -104,7 +104,7 @@ void bruteforce(uint8_t m, uint8_t e, uint8_t *mac) {
 			printf("%s\n", psk);
 		}
 	}
-	else if(m == 1) {
+	else if(model == 0x01) {
 		int32_t i;
 		unsigned char psk[ATT_NVG5XX_PSK_LEN];
 		for (i = 0; i < INT_MAX; i++) {
@@ -112,7 +112,7 @@ void bruteforce(uint8_t m, uint8_t e, uint8_t *mac) {
 			printf("%s\n", psk);
 		}
 	}
-	else if(m == 2 || m == 3 || m == 4) {
+	else if((model == 0x02 || model == 0x03 || model == 0x04) && (enc == 0x00 || enc == 0x01)) {
 		if(mac == NULL) {
 			printf("Invalid MAC address\n");
 			exit(1);
@@ -133,22 +133,24 @@ int main(int argc, char **argv) {
 		switch (opt) {
 
 		case 't': // target model number selection
-			model = (uint8_t) getModel(optarg);
-			if(model == END) {
+			if (getModel(optarg) != END) {
+				model = getModel(optarg);
+			} else {
 				usage_err();
 			}
 			break;
 
 		case 'e': // security/encryption mode selection
-			enc = (uint8_t) getEncryption(optarg);
-			if(enc == 0x03) {
+			if (getEncryption(optarg) != 0x03) {
+				enc = getEncryption(optarg);
+			} else {
 				usage_err();
 			}
 			break;
 
 		case 'm': // mac address selection
 			if (hex_string_to_byte_array(optarg, mac, BSSID_LEN)) {
-				printf("Invalid MAC address\n");
+				printf("Invalid MAC Address\n");
 				exit(2);
 			}
 			pMac = mac;
@@ -164,6 +166,7 @@ int main(int argc, char **argv) {
 		}
 		opt = getopt_long(argc, argv, option_string, long_options, &long_index);
 	}
+	printf("Model: %d \tEncryption: %d \tMac Address: %s\n", model, enc, pMac);
 	bruteforce(model, enc, pMac);
 	return 0;
 }

--- a/src/pskracker.c
+++ b/src/pskracker.c
@@ -32,13 +32,14 @@
 #include "xfinity.c"
 #include "tools.c"
 
-static const char *option_string = "t:b:s:Wh";
+static const char *option_string = "t:b:s:WVh";
 static const struct option long_options[] = {
 		{ "target",     required_argument,	0, 't' },
 		{ "bssid", 	required_argument,	0, 'b' },
 		{ "wps", 	no_argument,		0, 'W' },
 		{ "serial",     required_argument,	0, 's' },
 		{ "help",       no_argument,		0, 'h' },
+		{ "version",	no_argument,		0, 'V' },
 		{ 0, 0,	0, 0 }
 };
 
@@ -96,7 +97,7 @@ void bruteforce(char *target, uint8_t mode, uint8_t *pMac) {
 				printf("PSK: %s\n",genpassXHS(pMac));
 			}
 			else {
-				printf("Specify target bssid: -b <bssid>\n");
+				printf("[!] Specify target bssid for target %s: -b <bssid>\n", target);
 				exit(1);
 			}
 		}
@@ -145,6 +146,16 @@ int main(int argc, char **argv) {
 			usage_err();
 			break;
 
+		case 'V': // display version
+			if(argc > 2) {
+				printf("[!] Bad use of argument --version (-V)\n");
+				exit(1);
+			} 
+			else {
+				printf("PSKracker %s\n", LONG_VERSION);
+				exit(0);
+			}
+			break;
 		default:
 			break;
 		}

--- a/src/pskracker.c
+++ b/src/pskracker.c
@@ -129,8 +129,8 @@ int main(int argc, char **argv) {
 
 		case 'b':
 			if (hex_string_to_byte_array(optarg, mac, BSSID_LEN)) {
-				printf("Invalid MAC Address\n");
-				exit(2);
+				printf("[!] Invalid MAC Address\n");
+				exit(1);
 			}
 			pMac = mac;
 			break;

--- a/src/pskracker.c
+++ b/src/pskracker.c
@@ -35,11 +35,11 @@
 static const char *option_string = "t:b:s:Wh";
 static const struct option long_options[] = {
 		{ "target",     required_argument,	0, 't' },
-		{ "bssid", 		required_argument,	0, 'b' },
-		{ "wps", 		no_argument,		0, 'W' },
+		{ "bssid", 	required_argument,	0, 'b' },
+		{ "wps", 	no_argument,		0, 'W' },
 		{ "serial",     required_argument,	0, 's' },
 		{ "help",       no_argument,		0, 'h' },
-		{ 0,            0,					0,  0  }
+		{ 0, 0,	0, 0 }
 };
 
 void usage_err() {
@@ -56,14 +56,14 @@ void usage_err() {
 		"\n"
 		"Optional Arguments:\n"
 		"\n"
-		"	-b, --bssid			: BSSID of target\n"
-		"	-W, --wps			: Output possible WPS pin(s) only\n"
+		"	-b, --bssid		: BSSID of target\n"
+		"	-W, --wps		: Output possible WPS pin(s) only\n"
 		"	-s, --serial		: Serial number\n"
-		"	-h, --help			: Display help/usage\n"
+		"	-h, --help		: Display help/usage\n"
 		"\n"
 		"Example:\n"
 		"\n"
-		"	pskracker -t <target model> -b <bssid> -s <serial number>\n"
+		"pskracker -t <target model> -b <bssid> -s <serial number>\n"
 		"\n"
 	);
 	exit(1);

--- a/src/pskracker.c
+++ b/src/pskracker.c
@@ -30,6 +30,7 @@
 
 #include "att.c"
 #include "xfinity.c"
+#include "tools.c"
 
 char TARGET[9];
 char MODE[4];
@@ -68,39 +69,6 @@ void usage_err() {
 		"\n"
 	);
 	exit(1);
-}
-
-unsigned int hex_string_to_byte_array(char *in, uint8_t *out, const unsigned int n_len) {
-	unsigned int o, i, j;
-	unsigned int len = strlen(in);
-	unsigned int b_len = n_len * 2 + n_len - 1;
-
-	if (len != n_len * 2 && len != b_len)
-		return 1;
-	for (i = 0; i < n_len; i++) {
-		o = 0;
-		for (j = 0; j < 2; j++) {
-			o <<= 4;
-			if (*in >= 'A' && *in <= 'F')
-				*in += 'a'-'A';
-			if (*in >= '0' && *in <= '9')
-				o += *in - '0';
-			else
-				if (*in >= 'a' && *in <= 'f')
-					o += *in - 'a' + 10;
-				else
-					return 1;
-			in++;
-		}
-		*out++ = o;
-		if (len == b_len) {
-			if (*in == ':' || *in == '-' || *in == ' ' || *in == 0)
-				in++;
-			else
-				return 1;
-		}
-	}
-	return 0;
 }
 
 void bruteforce(uint8_t *mac) {

--- a/src/pskracker.c
+++ b/src/pskracker.c
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
 	int long_index = 0;
 	opt = getopt_long(argc, argv, option_string, long_options, &long_index);
 	while (opt != -1) {
-		switch (opt) { // default setting for variable options is 0
+		switch (opt) {
 
 		case 't':
 			mode = 0; // set WPA (bruteforce())

--- a/src/pskracker.c
+++ b/src/pskracker.c
@@ -73,7 +73,7 @@ void bruteforce(char *target, uint8_t mode, uint8_t *pMac) {
 	/* WPA */
 	if(mode == 0) {
 		/* ATT NVG589 */
-		if(!strcmp("nvg589", target)) {
+		if(!strcmp(STR_MODEL_NVG589, target)) {
 			int i;
 			unsigned char psk[ATT_NVG5XX_PSK_LEN];
 			for (i = 0; i < INT_MAX; i++) {
@@ -82,7 +82,7 @@ void bruteforce(char *target, uint8_t mode, uint8_t *pMac) {
 			}
 		}
 		/* ATT NVG599 */
-		else if(!strcmp("nvg599", target)) {
+		else if(!strcmp(STR_MODEL_NVG599, target)) {
 			int i;
 			unsigned char psk[ATT_NVG5XX_PSK_LEN];
 			for (i = 0; i < INT_MAX; i++) {
@@ -91,7 +91,7 @@ void bruteforce(char *target, uint8_t mode, uint8_t *pMac) {
 			}
 		}
 		/* Comcast/Xfinity Home Security DPC3939, DPC3491, TG1682G */
-		else if (!strcmp("dpc3939", target) || !strcmp("dpc3941", target) || !strcmp("tg1682g", target)) {
+		else if (!strcmp(STR_MODEL_DPC3939, target) || !strcmp(STR_MODEL_DPC3941, target) || !strcmp(STR_MODEL_TG1682G, target)) {
 			if(pMac != NULL) {
 				printf("PSK: %s\n",genpassXHS(pMac));
 			}

--- a/src/pskracker.h
+++ b/src/pskracker.h
@@ -1,3 +1,23 @@
+/*
+ * PSKracker: WPA/WPA2/WPS default key/pin generator written in C.
+ *
+ * Copyright (c) 2017, soxrok2212 <soxrok2212@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0+
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef PSKRACKER_H_
 #define PSKRACKER_H_
 

--- a/src/pskracker.h
+++ b/src/pskracker.h
@@ -29,7 +29,7 @@
 #define STR_ENC_WPA "wpa"
 #define STR_ENC_WPS "wps"
 
-/* MODELS */
+/* TARGETS */
 #define STR_MODEL_NVG589 "nvg589"
 #define STR_MODEL_NVG599 "nvg599"
 //#define STR_MODEL_7550      "7550"

--- a/src/pskracker.h
+++ b/src/pskracker.h
@@ -23,16 +23,36 @@
 
 /* General */
 #define BSSID_LEN 6
+#define END 0x02
 
-/* Encryption */
+/* Encryption Types*/
 #define STR_ENC_WPA "wpa"
 #define STR_ENC_WPS "wps"
 
-/* Targets */
-#define STR_TARGET_NVG589   "nvg589"
-#define STR_TARGET_NVG599   "nvg599"
-#define STR_TARGET_DPC3939  "dpc3939"
-#define STR_TARGET_DPC3941  "dpc3941"
-#define STR_TARGET_TG1682G  "tg1682g"
+/* MODELS */
+#define STR_MODEL_NVG589 "nvg589"
+#define STR_MODEL_NVG599 "nvg599"
+//#define STR_MODEL_7550      "7550"
+//#define STR_MODEL_5268AC    "5268ac"
+#define STR_MODEL_DPC3939 "dpc3939"
+#define STR_MODEL_DPC3941 "dpc3941"
+#define STR_MODEL_TG1682G "tg1682g"
+
+/* ISPS */
+#define STR_ISP_ATT "att"
+#define STR_ISP_BRIGTHOUSE "brighthouse"
+#define STR_ISP_CENTURYLINK "centurylink"
+#define STR_ISP_CHARTER "charter"
+#define STR_ISP_SPECTRUM "spectrum"
+#define STR_ISP_COMCAST "comcast"
+#define STR_ISP_XFINITY "xfintiy"
+#define STR_ISP_COX "cox"
+#define STR_ISP_FIOS "fios"
+#define STR_ISP_FRONTIER "frontier"
+#define STR_ISP_GOOGLE "google"
+#define STR_ISP_OPTIMUM "optimum"
+#define STR_ISP_SUDDENLINK "suddenlink"
+#define STR_ISP_TIMEWARNER "timewarner"
+#define STR_ISP_WOW "wow"
 
 #endif /* PSKRACKER_H_ */

--- a/src/pskracker.h
+++ b/src/pskracker.h
@@ -23,7 +23,7 @@
 
 /* General */
 #define BSSID_LEN 6
-#define END 0x02
+#define END 0x05
 
 /* Encryption Types*/
 #define STR_ENC_WPA "wpa"

--- a/src/pskracker.h
+++ b/src/pskracker.h
@@ -23,11 +23,7 @@
 
 /* General */
 #define BSSID_LEN 6
-#define END 0x05
 
-/* Encryption Types*/
-#define STR_ENC_WPA "wpa"
-#define STR_ENC_WPS "wps"
 
 /* TARGETS */
 #define STR_MODEL_NVG589 "nvg589"

--- a/src/pskracker.h
+++ b/src/pskracker.h
@@ -38,21 +38,4 @@
 #define STR_MODEL_DPC3941 "dpc3941"
 #define STR_MODEL_TG1682G "tg1682g"
 
-/* ISPS */
-#define STR_ISP_ATT "att"
-#define STR_ISP_BRIGTHOUSE "brighthouse"
-#define STR_ISP_CENTURYLINK "centurylink"
-#define STR_ISP_CHARTER "charter"
-#define STR_ISP_SPECTRUM "spectrum"
-#define STR_ISP_COMCAST "comcast"
-#define STR_ISP_XFINITY "xfintiy"
-#define STR_ISP_COX "cox"
-#define STR_ISP_FIOS "fios"
-#define STR_ISP_FRONTIER "frontier"
-#define STR_ISP_GOOGLE "google"
-#define STR_ISP_OPTIMUM "optimum"
-#define STR_ISP_SUDDENLINK "suddenlink"
-#define STR_ISP_TIMEWARNER "timewarner"
-#define STR_ISP_WOW "wow"
-
 #endif /* PSKRACKER_H_ */

--- a/src/tools.c
+++ b/src/tools.c
@@ -19,7 +19,6 @@
  */
 
  /* MAC Address Parser */
-
  unsigned int hex_string_to_byte_array(char *in, uint8_t *out, const unsigned int n_len) {
  	unsigned int o, i, j;
  	unsigned int len = strlen(in);

--- a/src/tools.c
+++ b/src/tools.c
@@ -18,10 +18,37 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef VERSION_H_
-#define VERSION_H_
+ /* MAC Address Parser */
 
-#define SHORT_VERSION "0.2"
-#define LONG_VERSION "0.2"
+ unsigned int hex_string_to_byte_array(char *in, uint8_t *out, const unsigned int n_len) {
+ 	unsigned int o, i, j;
+ 	unsigned int len = strlen(in);
+ 	unsigned int b_len = n_len * 2 + n_len - 1;
 
-#endif /* VERSION_H_ */
+ 	if (len != n_len * 2 && len != b_len)
+ 		return 1;
+ 	for (i = 0; i < n_len; i++) {
+ 		o = 0;
+ 		for (j = 0; j < 2; j++) {
+ 			o <<= 4;
+ 			if (*in >= 'A' && *in <= 'F')
+ 				*in += 'a'-'A';
+ 			if (*in >= '0' && *in <= '9')
+ 				o += *in - '0';
+ 			else
+ 				if (*in >= 'a' && *in <= 'f')
+ 					o += *in - 'a' + 10;
+ 				else
+ 					return 1;
+ 			in++;
+ 		}
+ 		*out++ = o;
+ 		if (len == b_len) {
+ 			if (*in == ':' || *in == '-' || *in == ' ' || *in == 0)
+ 				in++;
+ 			else
+ 				return 1;
+ 		}
+ 	}
+ 	return 0;
+ }

--- a/src/version.h
+++ b/src/version.h
@@ -22,6 +22,6 @@
 #define VERSION_H_
 
 #define SHORT_VERSION "0.2"
-#define LONG_VERSION "0.2"
+#define LONG_VERSION "0.2.1"
 
 #endif /* VERSION_H_ */

--- a/src/xfinity.c
+++ b/src/xfinity.c
@@ -77,9 +77,11 @@ static unsigned int sub_AQlY(int a1) {
         result = ((a1 << 8) | 0x80000000) >> v3;
         if (a1 & 0x80000000)
             result = -result;
-    } else if (v3 == -('a') && a1 << 9) {
+    }
+    else if (v3 == -('a') && a1 << 9) {
         result = 0;
-    } else {
+    }
+    else {
         if (!(a1 & 0x80000000))
         result = 0x7FFFFFFF;
     }
@@ -134,10 +136,12 @@ char *genpassXHS(uint8_t *mac) {
     vendorLen = strlen(PRIV_KEY_CHARS);
     for (i = 0; i != XHS_PSK_LEN; i++) {
         int16_t tmp = meld_integers(mac16[i % BSSID_LEN], PRIV_KEY_CHARS[i]);
-        if (vendorLen > i)
+        if (vendorLen > i) {
             psk[i] = meld_integers(PRIV_KEY_CHARS[i], tmp);
-        else
+        }
+        else {
             psk[i] = tmp;
+        }
     }
 psk[XHS_PSK_LEN] = '\0';
 return psk;

--- a/src/xfinity.c
+++ b/src/xfinity.c
@@ -1,4 +1,24 @@
 /*
+ * PSKracker: WPA/WPA2/WPS default key/pin generator written in C.
+ *
+ * Copyright (c) 2017, soxrok2212 <soxrok2212@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0+
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
  * Credits for discovering the vulnerability to:
  * Marc Newlin @marcnewlin, Logan Lamb, and Christopher Grayson @_lavalamp and CableTap.
  * Thank you AAnarchYY for R&D


### PR DESCRIPTION
**PSKracker 0.2.1**

- Option -e, --encryption has been removed and replaced with -W, --wps. By default, PSKracker will generate WPA possibilities (if any). Specifying -W will generate possible WPS PINs (if any).

- Option -m, --mac has been replaced with the more standardized option -b, --bssid. Functionality is the same.

- Option -V, --version has been added to display PSKracker version.

- Added more verbose error handing.